### PR TITLE
Hiding content until typesetting is complete

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,9 +25,16 @@ class MathJax extends React.Component {
 			<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
 			<script type="text/x-mathjax-config">
 				MathJax.Hub.Config(${options});
+				MathJax.Hub.Queue(function() {
+					document.getElementById("formula").style.visibility = '';
+				});
+
 			</script>
 			<script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js"></script>
-			${content}
+
+			<div id="formula" style="visibility: hidden;">
+				${content}
+			</div>
 		`;
 	}
 	render() {


### PR DESCRIPTION
It is not unusual for the original text to be visible before MathJax processes it. If MathJax needs to load any components (like its output jax the first time it is used), that is done asynchronously, so the page will be displayed in the meantime until the component is loaded.

You could set the div's `visibility:hidden` property before loading its contents, and then after it is loaded, typeset the math setting `visibility` to "" afterward. You would need to use the `MathJax.Hub.Queue` to synchronize that. 